### PR TITLE
Added queryType to options for more possibilities

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -16,7 +16,7 @@ const plugin = postcss.plugin('postcss-split-mq', options => {
     const updateContainers = createUpdaterFn(containers);
 
     // do the deed
-    CSS.walkAtRules('media', updateContainers);
+    CSS.walkAtRules(options.queryType || 'media', updateContainers);
 
     // write mq files
     await Promise.all(


### PR DESCRIPTION
I added the possibility to provide a 'queryType' in the options to also split a css file not just by media queries, but also by other queries (e.g. 'supports'). This is pretty handy to easily split a big css file into smaller files.