### PR TITLE
Add query type option

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,4 +93,22 @@ options = {
 
 ---
 
+You can also provide a `queryType` in the options, to split by other queries too. If no `queryType` is provided, the default will be `media`.
+
+e.g.
+```js
+options = {
+  outpath: './',
+  queryType: 'supports',
+  files: [
+    {
+      name: 'supports.css',
+      match: /(.*?)/
+    }
+  ]
+};
+```
+
+---
+
 This can be improved. Contributions are welcome. Create an issue if you see a problem or to ask a question.

--- a/src/main.js
+++ b/src/main.js
@@ -16,7 +16,7 @@ const plugin = postcss.plugin('postcss-split-mq', options => {
     const updateContainers = createUpdaterFn(containers);
 
     // do the deed
-    CSS.walkAtRules('media', updateContainers);
+    CSS.walkAtRules(options.queryType || 'media', updateContainers);
 
     // write mq files
     await Promise.all(


### PR DESCRIPTION
I added a queryType to the options (default will still be 'media'). This can be handsome, if you want to easily split a css file not only by media queries, but also by queries like 'supports'.

Please feel free to review my changes and I'm hopping to see a new version for npm too.